### PR TITLE
Update To embedded_hal 1.0.0 and embedded_graphics 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,8 @@ name = "ssd1680"
 version = "0.1.0"
 authors = ["Konstantin Terekhov <c@kmbv.info>"]
 description = "Driver for the SSD1680 e-Paper display (EPD) controller, for use with embedded-hal"
-edition = "2018"
+edition = "2021"
+rust-version = "1.75"
 
 documentation = "https://docs.rs/ssd1680"
 repository = "https://github.com/mbv/ssd1680"
@@ -15,8 +16,9 @@ categories = ["embedded", "no-std"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-embedded-hal = { version = "0.2.3", features = ["unproven"] }
-embedded-graphics = { version = "0.6.2", optional = true }
+embedded-hal = "1.0.0"
+embedded-graphics = { version = "0.8.1", optional = true }
+display-interface = "0.5.0"
 
 [features]
 default = ["graphics"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssd1680"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Konstantin Terekhov <c@kmbv.info>"]
 description = "Driver for the SSD1680 e-Paper display (EPD) controller, for use with embedded-hal"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Konstantin Terekhov <c@kmbv.info>"]
 description = "Driver for the SSD1680 e-Paper display (EPD) controller, for use with embedded-hal"
 edition = "2021"
-rust-version = "1.75"
 
 documentation = "https://docs.rs/ssd1680"
 repository = "https://github.com/mbv/ssd1680"

--- a/src/color.rs
+++ b/src/color.rs
@@ -4,9 +4,9 @@
 use embedded_graphics::pixelcolor::BinaryColor;
 
 #[cfg(feature = "graphics")]
-pub use BinaryColor::Off as White;
+pub use BinaryColor::Off as Black;
 #[cfg(feature = "graphics")]
-pub use BinaryColor::On as Black;
+pub use BinaryColor::On as White;
 #[cfg(feature = "graphics")]
 pub use BinaryColor::On as Red;
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -8,22 +8,23 @@ use crate::interface::DisplayInterface;
 use crate::{cmd, color, flag, HEIGHT, WIDTH};
 
 /// A configured display with a hardware interface.
-pub struct Ssd1680<SPI, OP, IP> {
-    interface: DisplayInterface<SPI, OP, IP>,
+pub struct Ssd1680<SPI, BSY, RST, DC> {
+    interface: DisplayInterface<SPI, BSY, RST, DC>,
 }
 
-impl<SPI, OP, IP> Ssd1680<SPI, OP, IP>
+impl<SPI, BSY, DC, RST> Ssd1680<SPI, BSY, DC, RST>
 where
     SPI: SpiDevice,
-    OP: OutputPin,
-    IP: InputPin,
+    RST: OutputPin,
+    DC: OutputPin,
+    BSY: InputPin,
 {
     /// Create and initialize the display driver
     pub fn new(
         spi: SPI,
-        busy: IP,
-        dc: OP,
-        rst: OP,
+        busy: BSY,
+        dc: DC,
+        rst: RST,
         delay: &mut impl DelayNs,
     ) -> Result<Self, DisplayError>
     where

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,105 +1,92 @@
 //! Driver for interacting with SSD1680 display driver
-use core::fmt::Debug;
-
-use embedded_hal::{
-    blocking::{delay::DelayMs, spi::Write},
-    digital::v2::{InputPin, OutputPin},
-};
+use display_interface::DisplayError;
+use embedded_hal::delay::DelayNs;
+use embedded_hal::digital::{InputPin, OutputPin};
+use embedded_hal::spi::SpiDevice;
 
 use crate::interface::DisplayInterface;
 use crate::{cmd, color, flag, HEIGHT, WIDTH};
 
 /// A configured display with a hardware interface.
-pub struct Ssd1680<SPI, CS, BUSY, DC, RST> {
-    interface: DisplayInterface<SPI, CS, BUSY, DC, RST>,
+pub struct Ssd1680<SPI, OP, IP> {
+    interface: DisplayInterface<SPI, OP, IP>,
 }
 
-impl<SPI, CS, BUSY, DC, RST> Ssd1680<SPI, CS, BUSY, DC, RST>
+impl<SPI, OP, IP> Ssd1680<SPI, OP, IP>
 where
-    SPI: Write<u8>,
-    CS: OutputPin,
-    CS::Error: Debug,
-    BUSY: InputPin,
-    DC: OutputPin,
-    DC::Error: Debug,
-    RST: OutputPin,
-    RST::Error: Debug,
+    SPI: SpiDevice,
+    OP: OutputPin,
+    IP: InputPin,
 {
     /// Create and initialize the display driver
-    pub fn new<DELAY: DelayMs<u8>>(
-        spi: &mut SPI,
-        cs: CS,
-        busy: BUSY,
-        dc: DC,
-        rst: RST,
-        delay: &mut DELAY,
-    ) -> Result<Self, SPI::Error>
+    pub fn new(
+        spi: SPI,
+        busy: IP,
+        dc: OP,
+        rst: OP,
+        delay: &mut impl DelayNs,
+    ) -> Result<Self, DisplayError>
     where
         Self: Sized,
     {
-        let interface = DisplayInterface::new(cs, busy, dc, rst);
+        let interface = DisplayInterface::new(spi, busy, dc, rst);
         let mut ssd1680 = Ssd1680 { interface };
-        ssd1680.init(spi, delay)?;
+        ssd1680.init(delay)?;
         Ok(ssd1680)
     }
 
     /// Initialise the controller
-    pub fn init<DELAY: DelayMs<u8>>(
-        &mut self,
-        spi: &mut SPI,
-        delay: &mut DELAY,
-    ) -> Result<(), SPI::Error> {
+    pub fn init(&mut self, delay: &mut impl DelayNs) -> Result<(), DisplayError> {
         self.interface.reset(delay);
-        self.interface.cmd(spi, cmd::Cmd::SW_RESET)?;
+        self.interface.cmd(cmd::Cmd::SW_RESET)?;
         self.interface.wait_until_idle(delay);
 
         self.interface
-            .cmd_with_data(spi, cmd::Cmd::DRIVER_CONTROL, &[HEIGHT - 1, 0x00, 0x00])?;
-
-        self.interface
-            .cmd_with_data(spi, cmd::Cmd::DATA_ENTRY_MODE, &[flag::Flag::DATA_ENTRY_INCRY_INCRX])?;
+            .cmd_with_data(cmd::Cmd::DRIVER_CONTROL, &[HEIGHT - 1, 0x00, 0x00])?;
 
         self.interface.cmd_with_data(
-            spi,
+            cmd::Cmd::DATA_ENTRY_MODE,
+            &[flag::Flag::DATA_ENTRY_INCRY_INCRX],
+        )?;
+
+        self.interface.cmd_with_data(
             cmd::Cmd::BORDER_WAVEFORM_CONTROL,
             &[flag::Flag::BORDER_WAVEFORM_FOLLOW_LUT | flag::Flag::BORDER_WAVEFORM_LUT1],
         )?;
 
         self.interface
-            .cmd_with_data(spi, cmd::Cmd::TEMP_CONTROL, &[flag::Flag::INTERNAL_TEMP_SENSOR])?;
+            .cmd_with_data(cmd::Cmd::TEMP_CONTROL, &[flag::Flag::INTERNAL_TEMP_SENSOR])?;
 
         self.interface
-            .cmd_with_data(spi, cmd::Cmd::DISPLAY_UPDATE_CONTROL, &[0x00, 0x80])?;
+            .cmd_with_data(cmd::Cmd::DISPLAY_UPDATE_CONTROL, &[0x00, 0x80])?;
 
-        self.use_full_frame(spi)?;
+        self.use_full_frame()?;
 
         self.interface.wait_until_idle(delay);
         Ok(())
     }
 
     /// Update the whole BW buffer on the display driver
-    pub fn update_bw_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
-        self.use_full_frame(spi)?;
+    pub fn update_bw_frame(&mut self, buffer: &[u8]) -> Result<(), DisplayError> {
+        self.use_full_frame()?;
         self.interface
-            .cmd_with_data(spi, cmd::Cmd::WRITE_BW_DATA, &buffer)
+            .cmd_with_data(cmd::Cmd::WRITE_BW_DATA, &buffer)
     }
 
     /// Update the whole Red buffer on the display driver
-    pub fn update_red_frame(&mut self, spi: &mut SPI, buffer: &[u8]) -> Result<(), SPI::Error> {
-        self.use_full_frame(spi)?;
+    pub fn update_red_frame(&mut self, buffer: &[u8]) -> Result<(), DisplayError> {
+        self.use_full_frame()?;
         self.interface
-            .cmd_with_data(spi, cmd::Cmd::WRITE_RED_DATA, &buffer)
+            .cmd_with_data(cmd::Cmd::WRITE_RED_DATA, &buffer)
     }
 
     /// Start an update of the whole display
-    pub fn display_frame<DELAY: DelayMs<u8>>(
-        &mut self,
-        spi: &mut SPI,
-        delay: &mut DELAY,
-    ) -> Result<(), SPI::Error> {
-        self.interface
-            .cmd_with_data(spi, cmd::Cmd::UPDATE_DISPLAY_CTRL2, &[flag::Flag::DISPLAY_MODE_1])?;
-        self.interface.cmd(spi, cmd::Cmd::MASTER_ACTIVATE)?;
+    pub fn display_frame(&mut self, delay: &mut impl DelayNs) -> Result<(), DisplayError> {
+        self.interface.cmd_with_data(
+            cmd::Cmd::UPDATE_DISPLAY_CTRL2,
+            &[flag::Flag::DISPLAY_MODE_1],
+        )?;
+        self.interface.cmd(cmd::Cmd::MASTER_ACTIVATE)?;
 
         self.interface.wait_until_idle(delay);
 
@@ -107,58 +94,55 @@ where
     }
 
     /// Make the whole black and white frame on the display driver white
-    pub fn clear_bw_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
-        self.use_full_frame(spi)?;
+    pub fn clear_bw_frame(&mut self) -> Result<(), DisplayError> {
+        self.use_full_frame()?;
 
         // TODO: allow non-white background color
         let color = color::Color::White.get_byte_value();
 
-        self.interface.cmd(spi, cmd::Cmd::WRITE_BW_DATA)?;
+        self.interface.cmd(cmd::Cmd::WRITE_BW_DATA)?;
         self.interface
-            .data_x_times(spi, color, u32::from(WIDTH) / 8 * u32::from(HEIGHT))?;
+            .data_x_times(color, u32::from(WIDTH) / 8 * u32::from(HEIGHT))?;
         Ok(())
     }
 
     /// Make the whole red frame on the display driver white
-    pub fn clear_red_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
-        self.use_full_frame(spi)?;
+    pub fn clear_red_frame(&mut self) -> Result<(), DisplayError> {
+        self.use_full_frame()?;
 
         // TODO: allow non-white background color
         let color = color::Color::White.inverse().get_byte_value();
 
-        self.interface.cmd(spi, cmd::Cmd::WRITE_RED_DATA)?;
+        self.interface.cmd(cmd::Cmd::WRITE_RED_DATA)?;
         self.interface
-            .data_x_times(spi, color, u32::from(WIDTH) / 8 * u32::from(HEIGHT))?;
+            .data_x_times(color, u32::from(WIDTH) / 8 * u32::from(HEIGHT))?;
         Ok(())
     }
 
-    fn use_full_frame(&mut self, spi: &mut SPI) -> Result<(), SPI::Error> {
+    fn use_full_frame(&mut self) -> Result<(), DisplayError> {
         // choose full frame/ram
-        self.set_ram_area(spi, 0, 0, u32::from(WIDTH) - 1, u32::from(HEIGHT) - 1)?;
+        self.set_ram_area(0, 0, u32::from(WIDTH) - 1, u32::from(HEIGHT) - 1)?;
 
         // start from the beginning
-        self.set_ram_counter(spi, 0, 0)
+        self.set_ram_counter(0, 0)
     }
 
     fn set_ram_area(
         &mut self,
-        spi: &mut SPI,
         start_x: u32,
         start_y: u32,
         end_x: u32,
         end_y: u32,
-    ) -> Result<(), SPI::Error> {
+    ) -> Result<(), DisplayError> {
         assert!(start_x < end_x);
         assert!(start_y < end_y);
 
         self.interface.cmd_with_data(
-            spi,
             cmd::Cmd::SET_RAMXPOS,
             &[(start_x >> 3) as u8, (end_x >> 3) as u8],
         )?;
 
         self.interface.cmd_with_data(
-            spi,
             cmd::Cmd::SET_RAMYPOS,
             &[
                 start_y as u8,
@@ -170,15 +154,15 @@ where
         Ok(())
     }
 
-    fn set_ram_counter(&mut self, spi: &mut SPI, x: u32, y: u32) -> Result<(), SPI::Error> {
+    fn set_ram_counter(&mut self, x: u32, y: u32) -> Result<(), DisplayError> {
         // x is positioned in bytes, so the last 3 bits which show the position inside a byte in the ram
         // aren't relevant
         self.interface
-            .cmd_with_data(spi, cmd::Cmd::SET_RAMX_COUNTER, &[(x >> 3) as u8])?;
+            .cmd_with_data(cmd::Cmd::SET_RAMX_COUNTER, &[(x >> 3) as u8])?;
 
         // 2 Databytes: A[7:0] & 0..A[8]
         self.interface
-            .cmd_with_data(spi, cmd::Cmd::SET_RAMY_COUNTER, &[y as u8, (y >> 8) as u8])?;
+            .cmd_with_data(cmd::Cmd::SET_RAMY_COUNTER, &[y as u8, (y >> 8) as u8])?;
         Ok(())
     }
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,5 +1,6 @@
 //! Driver for interacting with SSD1680 display driver
-use display_interface::DisplayError;
+pub use display_interface::DisplayError;
+
 use embedded_hal::delay::DelayNs;
 use embedded_hal::digital::{InputPin, OutputPin};
 use embedded_hal::spi::SpiDevice;

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -149,7 +149,15 @@ impl DrawTarget for Display2in13 {
 
 impl OriginDimensions for Display2in13 {
     fn size(&self) -> Size {
-        Size::new(WIDTH.into(), HEIGHT.into())
+        //if display is rotated 90 deg or 270 then swap height and width
+        match self.rotation() {
+            DisplayRotation::Rotate0 | DisplayRotation::Rotate180 => {
+                Size::new(WIDTH.into(), HEIGHT.into())
+            }
+            DisplayRotation::Rotate90 | DisplayRotation::Rotate270 => {
+                Size::new(HEIGHT.into(), WIDTH.into())
+            }
+        }
     }
 }
 

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -83,7 +83,7 @@ pub trait Display: DrawTarget {
 
         // "Draw" the Pixel on that bit
         match color {
-            // Black/Red
+            // White/Red
             BinaryColor::On => {
                 if is_inverted {
                     buffer[index] &= !bit;
@@ -91,7 +91,7 @@ pub trait Display: DrawTarget {
                     buffer[index] |= bit;
                 }
             }
-            // White
+            //Black
             BinaryColor::Off => {
                 if is_inverted {
                     buffer[index] |= bit;
@@ -117,7 +117,7 @@ impl Display2in13 {
         Display2in13 {
             buffer: [Color::White.get_byte_value(); buffer_len(WIDTH as usize, HEIGHT as usize)],
             rotation: DisplayRotation::default(),
-            is_inverted: true,
+            is_inverted: false,
         }
     }
 
@@ -260,7 +260,7 @@ mod tests {
             assert_eq!(byte, Color::White.get_byte_value());
         }
 
-        display.clear_buffer(Color::White);
+        display.clear_buffer(Color::Black);
 
         for &byte in display.buffer.iter() {
             assert_eq!(byte, Color::Black.get_byte_value());

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -242,7 +242,7 @@ mod tests {
     use super::{find_position, outside_display, Display, Display2in13, DisplayRotation};
     use crate::color::Black;
     use crate::color::Color;
-    use embedded_graphics::{prelude::*, primitives::Line, style::PrimitiveStyle};
+    use embedded_graphics::{prelude::*, primitives::Line, primitives::PrimitiveStyle};
 
     #[test]
     fn buffer_clear() {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -10,29 +10,30 @@ const RESET_DELAY_MS: u8 = 10;
 
 /// The Connection Interface of all (?) Waveshare EPD-Devices
 ///
-pub(crate) struct DisplayInterface<SPI, OP, IP> {
+pub(crate) struct DisplayInterface<SPI, BSY, DC, RST> {
     /// SPI device
     spi: SPI,
     /// Low for busy, Wait until display is ready!
-    busy: IP,
+    busy: BSY,
     /// Data/Command Control Pin (High for data, Low for command)
-    dc: OP,
+    dc: DC,
     /// Pin for Reseting
-    rst: OP,
+    rst: RST,
 }
 
-impl<SPI, OP, IP> DisplayInterface<SPI, OP, IP> {
+impl<SPI, BSY, DC, RST> DisplayInterface<SPI, BSY, DC, RST> {
     /// Create and initialize display
-    pub fn new(spi: SPI, busy: IP, dc: OP, rst: OP) -> Self {
+    pub fn new(spi: SPI, busy: BSY, dc: DC, rst: RST) -> Self {
         DisplayInterface { spi, busy, dc, rst }
     }
 }
 
-impl<SPI, OP, IP> DisplayInterface<SPI, OP, IP>
+impl<SPI, BSY, DC, RST> DisplayInterface<SPI, BSY, DC, RST>
 where
     SPI: SpiDevice,
-    OP: OutputPin,
-    IP: InputPin,
+    RST: OutputPin,
+    DC: OutputPin,
+    BSY: InputPin,
 {
     /// Basic function for sending commands
     pub(crate) fn cmd(&mut self, command: u8) -> Result<(), DisplayError> {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,122 +1,93 @@
 //! Display interface using SPI
-
-use core::fmt::Debug;
-use core::marker::PhantomData;
+use display_interface::DisplayError;
 use embedded_hal::{
-    blocking::{delay::DelayMs, spi::Write},
-    digital::v2::{InputPin, OutputPin},
+    delay::DelayNs,
+    digital::{InputPin, OutputPin},
+    spi::SpiDevice,
 };
 
 const RESET_DELAY_MS: u8 = 10;
 
 /// The Connection Interface of all (?) Waveshare EPD-Devices
 ///
-pub(crate) struct DisplayInterface<SPI, CS, BUSY, DC, RST> {
-    /// SPI
-    _spi: PhantomData<SPI>,
-    /// CS for SPI
-    cs: CS,
+pub(crate) struct DisplayInterface<SPI, OP, IP> {
+    /// SPI device
+    spi: SPI,
     /// Low for busy, Wait until display is ready!
-    busy: BUSY,
+    busy: IP,
     /// Data/Command Control Pin (High for data, Low for command)
-    dc: DC,
+    dc: OP,
     /// Pin for Reseting
-    rst: RST,
+    rst: OP,
 }
 
-impl<SPI, CS, BUSY, DC, RST> DisplayInterface<SPI, CS, BUSY, DC, RST>
-where
-    SPI: Write<u8>,
-    CS: OutputPin,
-    CS::Error: Debug,
-    BUSY: InputPin,
-    DC: OutputPin,
-    DC::Error: Debug,
-    RST: OutputPin,
-    RST::Error: Debug,
-{
+impl<SPI, OP, IP> DisplayInterface<SPI, OP, IP> {
     /// Create and initialize display
-    pub fn new(cs: CS, busy: BUSY, dc: DC, rst: RST) -> Self {
-        DisplayInterface {
-            _spi: PhantomData::default(),
-            cs,
-            busy,
-            dc,
-            rst,
-        }
+    pub fn new(spi: SPI, busy: IP, dc: OP, rst: OP) -> Self {
+        DisplayInterface { spi, busy, dc, rst }
     }
+}
 
+impl<SPI, OP, IP> DisplayInterface<SPI, OP, IP>
+where
+    SPI: SpiDevice,
+    OP: OutputPin,
+    IP: InputPin,
+{
     /// Basic function for sending commands
-    pub(crate) fn cmd(&mut self, spi: &mut SPI, command: u8) -> Result<(), SPI::Error> {
+    pub(crate) fn cmd(&mut self, command: u8) -> Result<(), DisplayError> {
         // low for commands
-        self.dc.set_low().unwrap();
+        self.dc.set_low().map_err(|_| DisplayError::DCError)?;
 
         // Transfer the command over spi
-        self.write(spi, &[command])
+        self.spi
+            .write(&[command])
+            .map_err(|_| DisplayError::BusWriteError)
     }
 
     /// Basic function for sending an array of u8-values of data over spi
-    pub(crate) fn data(&mut self, spi: &mut SPI, data: &[u8]) -> Result<(), SPI::Error> {
+    pub(crate) fn data(&mut self, data: &[u8]) -> Result<(), DisplayError> {
         // high for data
-        self.dc.set_high().unwrap();
+        self.dc.set_high().map_err(|_| DisplayError::DCError)?;
 
         // Transfer data (u8-array) over spi
-        self.write(spi, data)
+        self.spi
+            .write(data)
+            .map_err(|_| DisplayError::BusWriteError)
     }
 
     /// Basic function for sending a command and the data belonging to it.
-    pub(crate) fn cmd_with_data(
-        &mut self,
-        spi: &mut SPI,
-        command: u8,
-        data: &[u8],
-    ) -> Result<(), SPI::Error> {
-        self.cmd(spi, command)?;
-        self.data(spi, data)
+    pub(crate) fn cmd_with_data(&mut self, command: u8, data: &[u8]) -> Result<(), DisplayError> {
+        self.cmd(command)?;
+        self.data(data)
     }
 
     /// Basic function for sending the same byte of data (one u8) multiple times over spi
     /// Used for setting one color for the whole frame
-    pub(crate) fn data_x_times(
-        &mut self,
-        spi: &mut SPI,
-        val: u8,
-        repetitions: u32,
-    ) -> Result<(), SPI::Error> {
+    pub(crate) fn data_x_times(&mut self, val: u8, repetitions: u32) -> Result<(), DisplayError> {
         // high for data
         let _ = self.dc.set_high();
         // Transfer data (u8) over spi
         for _ in 0..repetitions {
-            self.write(spi, &[val])?;
+            self.spi
+                .write(&[val])
+                .map_err(|_| DisplayError::BusWriteError)?;
         }
         Ok(())
     }
 
     /// Waits until device isn't busy anymore (busy == HIGH)
-    pub(crate) fn wait_until_idle<DELAY: DelayMs<u8>>(&mut self, delay: &mut DELAY) {
-        while self.busy.is_high().unwrap_or(true) { delay.delay_ms(1) }
+    pub(crate) fn wait_until_idle(&mut self, delay: &mut impl DelayNs) {
+        while self.busy.is_high().unwrap_or(true) {
+            delay.delay_ms(1)
+        }
     }
 
     /// Resets the device.
-    pub(crate) fn reset<DELAY: DelayMs<u8>>(&mut self, delay: &mut DELAY) {
+    pub(crate) fn reset(&mut self, delay: &mut impl DelayNs) {
         self.rst.set_low().unwrap();
-        delay.delay_ms(RESET_DELAY_MS);
+        delay.delay_ms(RESET_DELAY_MS.into());
         self.rst.set_high().unwrap();
-        delay.delay_ms(RESET_DELAY_MS);
-    }
-
-    // spi write helper/abstraction function
-    fn write(&mut self, spi: &mut SPI, data: &[u8]) -> Result<(), SPI::Error> {
-        // activate spi with cs low
-        self.cs.set_low().unwrap();
-
-        for data_chunk in data.chunks(4096) {
-            spi.write(data_chunk)?;
-        }
-
-        // deativate spi with cs high
-        self.cs.set_high().unwrap();
-
-        Ok(())
+        delay.delay_ms(RESET_DELAY_MS.into());
     }
 }


### PR DESCRIPTION
## Embedded Hal Related Changes

- Move to using SPIDevice instead of generic Write<u8>. Removes the need for manual CS pin controlling. This could also be replaced with display_interface's WriteOnlyDataCommand trait to be made more generic.
- Replace DelayMs trait usage with DelayNs where needed. DelayMs no longer exists
- Updates various functions to use SPIDevice held by the display rather than one passed to the function

## Embedded Graphics Related Changes

- Update DrawTarget trait implementation to lastest  version. Which replaces draw_pixel with draw_iter
- Add OriginDimensions Trait implementation and update size function to swap width and height when rotated
- Invert Binary::On and Off to match colors expected by embedded_graphics

## Misc Changes

- Update error returned by driver to use [display_interface crate's](https://docs.rs/display-interface/latest/display_interface/) [DisplayError](https://docs.rs/display-interface/latest/display_interface/enum.DisplayError.html) type. Allows returning errors for issues with setting pins instead of panic, also will make it easier to switch to display_interface's traits in the future.

I've tested the changes on my ESP32S3 with a BW E ink screen hooked up and seems to be working well. My display doesn't seem to support the red layer so I'm not able to test that.